### PR TITLE
Sign in box should not refer to LDAP - Issue #10

### DIFF
--- a/webapp/app/partials/login.html
+++ b/webapp/app/partials/login.html
@@ -6,7 +6,7 @@
                     <div class="login-box box box-solid">
                         <div class="box-header">
                             <div class="box-title">
-                                <h4 class="header blue lighter bigger"> <i class="ace-icon fa fa-coffee green"></i> Sign in via LDAP </h4>
+                                <h4 class="header blue lighter bigger"> <i class="ace-icon fa fa-coffee green"></i> Sign in </h4>
                             </div>
                         </div>
                         <div class="box-body">


### PR DESCRIPTION
Issue #10 mentions 2 messages on login screen, one was fixed in previous commit while this was missed 
