### PR TITLE
Enable connections to Hbase with Zookeeper Quorum of more than 1 node

### DIFF
--- a/common/src/main/java/com/kylinolap/common/util/HadoopUtil.java
+++ b/common/src/main/java/com/kylinolap/common/util/HadoopUtil.java
@@ -72,7 +72,7 @@ public class HadoopUtil {
             return conf;
 
         // case of "hbase:domain.com:2181:/hbase-unsecure"
-        Pattern urlPattern = Pattern.compile("([\\w\\d\\-.]+)[:](\\d+)(?:[:](.*))?");
+        Pattern urlPattern = Pattern.compile("([\\w\\d\\-.,]+)[:](\\d+)(?:[:](.*))?");
         Matcher m = urlPattern.matcher(url);
         if (m.matches() == false)
             throw new IllegalArgumentException("HBase URL '" + url + "' is invalid, expected url is like '" + "hbase:domain.com:2181:/hbase-unsecure" + "'");
@@ -81,7 +81,8 @@ public class HadoopUtil {
 
         String quorum = m.group(1);
         try {
-            InetAddress.getByName(quorum);
+            for (String quorum_node : quorum.split(","))
+                InetAddress.getByName(quorum_node);
         } catch (UnknownHostException e) {
             throw new IllegalArgumentException("Zookeeper quorum is invalid: " + quorum + "; urlString=" + url, e);
         }


### PR DESCRIPTION
Addresses #134

Modified the regex & InetAddress checker to allow a Zookeeper Quorum string of the following format zk1.myco.com,zk2.myco.com,zk3.myco.com:2181 to be verified.
