### PR TITLE
confirm   local cmd  or  remote cmd

### DIFF
--- a/common/src/main/java/com/kylinolap/common/util/CliCommandExecutor.java
+++ b/common/src/main/java/com/kylinolap/common/util/CliCommandExecutor.java
@@ -81,7 +81,7 @@ public class CliCommandExecutor {
             r = runRemoteCommand(command);
 
         if (r.getFirst() != 0)
-            throw new IOException("OS command error exit with " + r.getFirst() + " -- " + command + "\n" + r.getSecond());
+            throw new IOException(remoteHost==null?"":("remoteHost:"+remoteHost)+"OS command error exit with " + r.getFirst() + " -- " + command + "\n" + r.getSecond());
 
         return r.getSecond();
     }


### PR DESCRIPTION
confirm   local cmd  or  remote cmd.
when i operation web there is  a problem as follow,so i want to add this sentense to confirm
"[http-bio-7070-exec-2]:[2014-12-06 12:27:10,493][ERROR][com.kylinolap.rest.controller.BasicController.handleError(BasicController.java:49)] - Internal error (Exception) throw out of controller
java.io.IOException: OS command error exit with 127 -- hive -e "use DEFAULT; show table extended like table_name; "
