### PR TITLE
JDBC Driver not register into DriverManager

### DIFF
--- a/jdbc/src/main/java/org/apache/kylin/jdbc/Driver.java
+++ b/jdbc/src/main/java/org/apache/kylin/jdbc/Driver.java
@@ -18,6 +18,7 @@
 
 package org.apache.kylin.jdbc;
 
+import java.sql.DriverManager;
 import java.sql.SQLException;
 
 import net.hydromatic.avatica.AvaticaConnection;
@@ -81,7 +82,13 @@ public class Driver extends UnregisteredDriver {
     private static final Logger logger = LoggerFactory.getLogger(Driver.class);
 
     public static final String CONNECT_STRING_PREFIX = "jdbc:kylin:";
-
+    static {
+        try {
+            DriverManager.registerDriver(new Driver());
+        } catch (SQLException e) {
+            throw new RuntimeException("Error occurred while registering JDBC driver " + Driver.class.getName() + ": " + e.toString());
+        }
+    }
     @Override
     protected DriverVersion createDriverVersion() {
         return DriverVersion.load(Driver.class, "org-apache-kylin-jdbc.properties", "Kylin JDBC Driver", "unknown version", "Kylin", "unknown version");


### PR DESCRIPTION
The Driver not register into DriverManager
when use spring to manage the datasource pool with org.apache.commons.dbcp.BasicDataSource
got exception:
Exception in thread "main" java.sql.SQLException: No suitable driver found for jdbc:kylin://x.x.x.x/default
at java.sql.DriverManager.getConnection(DriverManager.java:596)
at java.sql.DriverManager.getConnection(DriverManager.java:187)

jira:
https://issues.apache.org/jira/browse/KYLIN-657