### PR TITLE
KYLIN-752 improve query performance for values are not in dictionary

### DIFF
--- a/storage/src/main/java/org/apache/kylin/storage/hbase/CubeStorageEngine.java
+++ b/storage/src/main/java/org/apache/kylin/storage/hbase/CubeStorageEngine.java
@@ -481,7 +481,7 @@ public class CubeStorageEngine implements IStorageEngine {
                 break;
             }
 
-            ColumnValueRange range = new ColumnValueRange(comp.getColumn(), comp.getValues(), comp.getOperator());
+            ColumnValueRange range = new ColumnValueRange(comp.getColumn(), newValues, comp.getOperator());
             andMerge(range, rangeMap);
 
         }

--- a/storage/src/main/java/org/apache/kylin/storage/hbase/CubeStorageEngine.java
+++ b/storage/src/main/java/org/apache/kylin/storage/hbase/CubeStorageEngine.java
@@ -422,8 +422,10 @@ public class CubeStorageEngine implements IStorageEngine {
             }
 
             Collection<ColumnValueRange> andRanges = translateToAndDimRanges(andFilter.getChildren(), cubeSegment);
-
-            result.add(andRanges);
+            // ignore the empty-AND
+            if (andRanges != null && !andRanges.isEmpty()) {
+                result.add(andRanges);
+            }
         }
 
         return preprocessConstantConditions(result);
@@ -459,6 +461,7 @@ public class CubeStorageEngine implements IStorageEngine {
 
     private Collection<ColumnValueRange> translateToAndDimRanges(List<? extends TupleFilter> andFilters, CubeSegment cubeSegment) {
         Map<TblColRef, ColumnValueRange> rangeMap = new HashMap<TblColRef, ColumnValueRange>();
+        boolean isEmptyAnd = false;
         for (TupleFilter filter : andFilters) {
             if ((filter instanceof CompareTupleFilter) == false) {
                 continue;
@@ -469,11 +472,20 @@ public class CubeStorageEngine implements IStorageEngine {
                 continue;
             }
 
+            // optimize the values of tuple filter
+            Collection<String> newValues = TupleFilterValueOptimizer.doOptimization(cubeSegment, comp.getColumn(), comp);
+            // in case the current filter is an empty-AND, do not generate ColumnValueRange
+            // and also set isEmptyAnd to true so that an empty AND-list will be returned
+            if (TupleFilterValueOptimizer.isEmptyAnd(comp, newValues)) {
+                isEmptyAnd = true;
+                break;
+            }
+
             ColumnValueRange range = new ColumnValueRange(comp.getColumn(), comp.getValues(), comp.getOperator());
             andMerge(range, rangeMap);
 
         }
-        return rangeMap.values();
+        return isEmptyAnd ? Collections.<ColumnValueRange> emptyList() : rangeMap.values();
     }
 
     private void andMerge(ColumnValueRange range, Map<TblColRef, ColumnValueRange> rangeMap) {

--- a/storage/src/main/java/org/apache/kylin/storage/hbase/TupleFilterValueOptimizer.java
+++ b/storage/src/main/java/org/apache/kylin/storage/hbase/TupleFilterValueOptimizer.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.apache.kylin.storage.hbase;
+
+import org.apache.kylin.cube.CubeSegment;
+import org.apache.kylin.cube.kv.RowKeyColumnIO;
+import org.apache.kylin.dict.Dictionary;
+import org.apache.kylin.metadata.model.TblColRef;
+import org.apache.kylin.metadata.filter.CompareTupleFilter;
+import org.apache.kylin.metadata.filter.TupleFilter;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+/**
+ * @author Huang, Hua(huanghua@mininglamp.com)
+ */
+public class TupleFilterValueOptimizer {
+
+    private static boolean isInDictionary(Dictionary<String> dict, String value) {
+        boolean inFlag = true;
+        try {
+            int id = dict.getIdFromValue(value, 0);
+        } catch (IllegalArgumentException ex) {
+            inFlag = false;
+        }
+
+        return inFlag;
+    }
+
+    private static Collection<String> removeNonDictionaryValues(CubeSegment cubeSegment, TblColRef column, Collection<String> values) {
+        RowKeyColumnIO rowKeyColumnIO = new RowKeyColumnIO(cubeSegment);
+
+        Dictionary<String> dict = rowKeyColumnIO.getDictionary(column);
+        // in case that dict is null, just return values
+        if (dict == null) return values;
+
+        Collection<String> newValues = new LinkedList<String>();
+        for (String value : values) {
+            if (isInDictionary(dict, value)) newValues.add(value);
+        }
+
+        return newValues;
+    }
+
+    private static Collection<String> roundDictionaryValues(CubeSegment cubeSegment, TblColRef column, Collection<String> values, int roundingFlag) {
+        RowKeyColumnIO rowKeyColumnIO = new RowKeyColumnIO(cubeSegment);
+
+        Dictionary<String> dict = rowKeyColumnIO.getDictionary(column);
+        // in case that dict is null, just return values
+        if (dict == null) return values;
+
+        Collection<String> newValues = new LinkedList<String>();
+        for (String value : values) {
+            if (isInDictionary(dict, value)) {
+                newValues.add(value);
+            }
+            else {
+                try {
+                    int id = dict.getIdFromValue(value, roundingFlag);
+                    String newValue = dict.getValueFromId(id);
+                    newValues.add(newValue);
+                } catch (IllegalArgumentException ex) {
+                }
+            }
+        }
+
+        return newValues;
+    }
+
+    private static Collection<String> optimizeCompareTupleFilter(CubeSegment cubeSegment, TblColRef column, CompareTupleFilter comp) {
+        Collection<String> newValues = comp.getValues();
+        switch (comp.getOperator()) {
+            case EQ:
+            case IN:
+                newValues = removeNonDictionaryValues(cubeSegment, column, comp.getValues());
+                break;
+            case LT:
+            case LTE:
+                newValues = roundDictionaryValues(cubeSegment, column, comp.getValues(), -1);
+                break;
+            case GT:
+            case GTE:
+                newValues = roundDictionaryValues(cubeSegment, column, comp.getValues(), 1);
+                break;
+            default:
+                break;
+        }
+
+        return newValues;
+    }
+
+    public static Collection<String> doOptimization(CubeSegment cubeSegment, TblColRef column, TupleFilter filter) {
+        if (filter instanceof CompareTupleFilter) {
+            return optimizeCompareTupleFilter(cubeSegment, column, (CompareTupleFilter)filter);
+        }
+
+        return filter.getValues();
+    }
+
+    public static boolean isEmptyAnd(TupleFilter filter, Collection<String> values) {
+        boolean isEmptyAnd = false;
+        switch (filter.getOperator()) {
+            case EQ:
+            case IN:
+            case LT:
+            case LTE:
+            case GT:
+            case GTE:
+                if (values == null || values.isEmpty()) {
+                    isEmptyAnd = true;
+                }
+                break;
+            default:
+                break;
+        }
+
+        return isEmptyAnd;
+    }
+}


### PR DESCRIPTION
A quick fix to drop the not-in-dictionary values before generating hbase
scan range. And based on it, we can make a further optimization that as
long as there is at least one andFilter is empty(after we drop the
not-in-dictionary values), we can simply assert that the whole
andFilters is empty to avoid an unnecessary hbase scan. However, this
strategy only works for 'EQ', 'IN'.
For 'LT', 'LTE', 'GT', 'GTE', we have to replace them with the some sort
of closest smaller or bigger values by calling "final public int
getIdFromValue(T value, int roundingFlag)" of "Dictionary" class.