### PR TITLE
Dont rely on default encoding

### DIFF
--- a/common/src/main/java/org/apache/kylin/common/util/SSHClient.java
+++ b/common/src/main/java/org/apache/kylin/common/util/SSHClient.java
@@ -28,6 +28,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 
 import org.slf4j.LoggerFactory;
 
@@ -89,7 +90,7 @@ public class SSHClient {
                 // The access time should be sent here,
                 // but it is not accessible with JavaAPI ;-<
                 command += (" " + (_lfile.lastModified() / 1000) + " 0\n");
-                out.write(command.getBytes());
+                out.write(command.getBytes(Charset.forName("UTF-8")));
                 out.flush();
                 if (checkAck(in) != 0) {
                     throw new Exception("Error in checkAck()");
@@ -292,7 +293,7 @@ public class SSHClient {
                     if (i < 0)
                         break;
 
-                    String line = new String(tmp, 0, i);
+                    String line = new String(tmp, 0, i, Charset.forName("UTF-8"));
                     text.append(line);
                     if (logAppender != null) {
                         logAppender.log(line);

--- a/cube/src/main/java/org/apache/kylin/cube/model/CubeDesc.java
+++ b/cube/src/main/java/org/apache/kylin/cube/model/CubeDesc.java
@@ -33,6 +33,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import java.nio.charset.Charset;
+
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.net.util.Base64;
@@ -409,8 +411,8 @@ public class CubeDesc extends RootPersistentEntity {
             StringBuilder sigString = new StringBuilder();
             sigString.append(this.name).append("|").append(this.getFactTable()).append("|").append(JsonUtil.writeValueAsString(this.model.getPartitionDesc())).append("|").append(JsonUtil.writeValueAsString(this.dimensions)).append("|").append(JsonUtil.writeValueAsString(this.measures)).append("|").append(JsonUtil.writeValueAsString(this.rowkey)).append("|").append(JsonUtil.writeValueAsString(this.hbaseMapping));
 
-            byte[] signature = md.digest(sigString.toString().getBytes());
-            return new String(Base64.encodeBase64(signature));
+            byte[] signature = md.digest(sigString.toString().getBytes(Charset.forName("UTF-8")));
+            return new String(Base64.encodeBase64(signature), Charset.forName("UTF-8"));
         } catch (NoSuchAlgorithmException | JsonProcessingException e) {
             throw new RuntimeException("Failed to calculate signature");
         }

--- a/cube/src/main/java/org/apache/kylin/cube/model/v1/CubeDesc.java
+++ b/cube/src/main/java/org/apache/kylin/cube/model/v1/CubeDesc.java
@@ -18,6 +18,7 @@
 
 package org.apache.kylin.cube.model.v1;
 
+import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -454,8 +455,8 @@ public class CubeDesc extends RootPersistentEntity {
             StringBuilder sigString = new StringBuilder();
             sigString.append(this.name).append("|").append(this.factTable).append("|").append(JsonUtil.writeValueAsString(this.cubePartitionDesc)).append("|").append(JsonUtil.writeValueAsString(this.dimensions)).append("|").append(JsonUtil.writeValueAsString(this.measures)).append("|").append(JsonUtil.writeValueAsString(this.rowkey)).append("|").append(JsonUtil.writeValueAsString(this.hbaseMapping));
 
-            byte[] signature = md.digest(sigString.toString().getBytes());
-            return new String(Base64.encodeBase64(signature));
+            byte[] signature = md.digest(sigString.toString().getBytes(Charset.forName("UTF-8")));
+            return new String(Base64.encodeBase64(signature), Charset.forName("UTF-8"));
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("Failed to calculate signature");
         } catch (JsonProcessingException e) {

--- a/invertedindex/src/main/java/org/apache/kylin/invertedindex/model/IIDesc.java
+++ b/invertedindex/src/main/java/org/apache/kylin/invertedindex/model/IIDesc.java
@@ -18,6 +18,7 @@
 
 package org.apache.kylin.invertedindex.model;
 
+import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -356,8 +357,8 @@ public class IIDesc extends RootPersistentEntity {
             StringBuilder sigString = new StringBuilder();
             sigString.append(this.name).append("|").append(this.getFactTableName()).append("|").append(timestampDimension).append("|").append(JsonUtil.writeValueAsString(this.bitmapDimensions)).append("|").append(JsonUtil.writeValueAsString(valueDimensions)).append("|").append(JsonUtil.writeValueAsString(this.metricNames)).append("|").append(sharding).append("|").append(sliceSize);
 
-            byte[] signature = md.digest(sigString.toString().getBytes());
-            return new String(Base64.encodeBase64(signature));
+            byte[] signature = md.digest(sigString.toString().getBytes(Charset.forName("UTF-8")));
+            return new String(Base64.encodeBase64(signature), Charset.forName("UTF-8"));
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("Failed to calculate signature");
         } catch (JsonProcessingException e) {

--- a/jdbc/src/main/java/org/apache/kylin/jdbc/KylinConnectionImpl.java
+++ b/jdbc/src/main/java/org/apache/kylin/jdbc/KylinConnectionImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.kylin.jdbc;
 
+import java.nio.charset.Charset;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -99,7 +100,7 @@ public abstract class KylinConnectionImpl extends AvaticaConnection {
         String username = this.info.getProperty("user");
         String password = this.info.getProperty("password");
 
-        return DatatypeConverter.printBase64Binary((username + ":" + password).getBytes());
+        return DatatypeConverter.printBase64Binary((username + ":" + password).getBytes(Charset.forName("UTF-8")));
     }
 
     public String getConnectUrl() {

--- a/jdbc/src/main/java/org/apache/kylin/jdbc/util/SQLTypeMap.java
+++ b/jdbc/src/main/java/org/apache/kylin/jdbc/util/SQLTypeMap.java
@@ -19,6 +19,7 @@
 package org.apache.kylin.jdbc.util;
 
 import java.math.BigDecimal;
+import java.nio.charset.Charset;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -169,7 +170,7 @@ public class SQLTypeMap {
         case Types.BINARY:
         case Types.VARBINARY:
         case Types.LONGVARBINARY:
-            return value.getBytes();
+            return value.getBytes(Charset.forName("UTF-8"));
         case Types.DATE:
             return Date.valueOf(value);
         case Types.TIME:

--- a/job/src/main/java/org/apache/kylin/job/tools/GridTableHBaseBenchmark.java
+++ b/job/src/main/java/org/apache/kylin/job/tools/GridTableHBaseBenchmark.java
@@ -19,6 +19,7 @@
 package org.apache.kylin.job.tools;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Random;
 
@@ -45,8 +46,8 @@ import com.google.common.collect.Lists;
 public class GridTableHBaseBenchmark {
 
     private static final String TEST_TABLE = "GridTableTest";
-    private static final byte[] CF = "F".getBytes();
-    private static final byte[] QN = "C".getBytes();
+    private static final byte[] CF = "F".getBytes(Charset.forName("UTF-8"));
+    private static final byte[] QN = "C".getBytes(Charset.forName("UTF-8"));
     private static final int N_ROWS = 10000;
     private static final int CELL_SIZE = 128 * 1024; // 128 KB
     private static final double DFT_HIT_RATIO = 0.3;

--- a/metadata/src/main/java/org/apache/kylin/metadata/measure/fixedlen/FixedHLLCodec.java
+++ b/metadata/src/main/java/org/apache/kylin/metadata/measure/fixedlen/FixedHLLCodec.java
@@ -18,6 +18,7 @@
 package org.apache.kylin.metadata.measure.fixedlen;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 
 import org.apache.kylin.common.hll.HyperLogLogPlusCounter;
 import org.apache.kylin.metadata.model.DataType;
@@ -53,7 +54,7 @@ public class FixedHLLCodec extends FixedLenMeasureCodec<HyperLogLogPlusCounter> 
         if (value == null)
             current.add("__nUlL__");
         else
-            current.add(value.getBytes());
+            current.add(value.getBytes(Charset.forName("UTF-8")));
         return current;
     }
 

--- a/server/src/main/java/org/apache/kylin/rest/security/LdapProvider.java
+++ b/server/src/main/java/org/apache/kylin/rest/security/LdapProvider.java
@@ -18,6 +18,7 @@
 
 package org.apache.kylin.rest.security;
 
+import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -74,7 +75,7 @@ public class LdapProvider extends LdapAuthenticationProvider {
         Authentication authed = null;
         Cache userCache = cacheManager.getCache("UserCache");
         md.reset();
-        byte[] hashKey = md.digest((authentication.getName() + authentication.getCredentials()).getBytes());
+        byte[] hashKey = md.digest((authentication.getName() + authentication.getCredentials()).getBytes(Charset.forName("UTF-8")));
         String userKey = Arrays.toString(hashKey);
 
         Element authedUser = userCache.get(userKey);

--- a/server/src/main/java/org/apache/kylin/rest/security/PasswordPlaceholderConfigurer.java
+++ b/server/src/main/java/org/apache/kylin/rest/security/PasswordPlaceholderConfigurer.java
@@ -18,6 +18,7 @@
 
 package org.apache.kylin.rest.security;
 
+import java.nio.charset.Charset;
 import java.util.Properties;
 
 import javax.crypto.Cipher;
@@ -50,7 +51,7 @@ public class PasswordPlaceholderConfigurer extends PropertyPlaceholderConfigurer
             Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
             final SecretKeySpec secretKey = new SecretKeySpec(key, "AES");
             cipher.init(Cipher.ENCRYPT_MODE, secretKey);
-            final String encryptedString = Base64.encodeBase64String(cipher.doFinal(strToEncrypt.getBytes()));
+            final String encryptedString = Base64.encodeBase64String(cipher.doFinal(strToEncrypt.getBytes(Charset.forName("UTF-8"))));
             return encryptedString;
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
@@ -62,7 +63,7 @@ public class PasswordPlaceholderConfigurer extends PropertyPlaceholderConfigurer
             Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5PADDING");
             final SecretKeySpec secretKey = new SecretKeySpec(key, "AES");
             cipher.init(Cipher.DECRYPT_MODE, secretKey);
-            final String decryptedString = new String(cipher.doFinal(Base64.decodeBase64(strToDecrypt)));
+            final String decryptedString = new String(cipher.doFinal(Base64.decodeBase64(strToDecrypt)), Charset.forName("UTF-8"));
             return decryptedString;
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);

--- a/server/src/main/java/org/apache/kylin/rest/service/AdminService.java
+++ b/server/src/main/java/org/apache/kylin/rest/service/AdminService.java
@@ -20,6 +20,7 @@ package org.apache.kylin.rest.service;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.Map;
 import java.util.Properties;
 
@@ -74,7 +75,11 @@ public class AdminService extends BasicService {
 
             // do save
             tempConfig.save(baos);
-            content = baos.toString();
+            try {
+                content = baos.toString("UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                content = baos.toString();
+            }
             return content;
         } catch (ConfigurationException e) {
             throw new InternalErrorException("Failed to get Kylin env Config", e);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1943 Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943


Please let me know if you have any questions.

Zeeshan